### PR TITLE
Remove meeting scheduler links from contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,11 +108,7 @@
           <!--<p class="wow fadeInLeft">635 Downey Way <br>Los Angeles, CA 90089-3332</p>
           <p class="wow fadeInLeft"><strong>Phone:</strong> 801-360-7650</p>-->
           <p class="wow fadeInLeft"><strong>Email:</strong> joelhbkr@gmail.com; joel@metr.org; joel@qallys.com</p>
-          <p class="wow fadeInLeft"><strong>Meeting Calendar: </strong> 
-            <a href="https://savvycal.com/joelhbkr/chat" target="_blank">preferred times</a>, 
-            <a href="https://savvycal.com/joelhbkr/all-times" target="_blank">all times</a>
-          </p>
-          <p class="wow fadeInLeft"><strong>Anonymous Feedback:</strong> 
+          <p class="wow fadeInLeft"><strong>Anonymous Feedback:</strong>
             <a href="https://docs.google.com/forms/d/e/1FAIpQLSeEENPq8XqcprR2JjaYqHSA9kvpUEf9pxuKL08uDoZckEoUOA/viewform" target="_blank">form</a>
           </p>
 
@@ -345,11 +341,7 @@
           <div class="row">
             <div class="col-12 mb-4">
               <p class="wow fadeInLeft"><strong>Email:</strong> joelhbkr@gmail.com; joel@metr.org; joel@qallys.com</p>
-              <p class="wow fadeInLeft"><strong>Meeting Calendar:</strong> 
-                <a href="https://savvycal.com/joelhbkr/chat" target="_blank">preferred times</a>, 
-                <a href="https://savvycal.com/joelhbkr/all-times" target="_blank">all times</a>
-              </p>
-              <p class="wow fadeInLeft"><strong>Anonymous Feedback:</strong> 
+              <p class="wow fadeInLeft"><strong>Anonymous Feedback:</strong>
                 <a href="https://docs.google.com/forms/d/e/1FAIpQLSeEENPq8XqcprR2JjaYqHSA9kvpUEf9pxuKL08uDoZckEoUOA/viewform" target="_blank">form</a></p>
               <div class="social-box" style="text-align: left;">
                 <ul style="padding-left: 0;">


### PR DESCRIPTION
## Summary
- Removed the "Meeting Calendar" paragraph (SavvyCal `preferred times` / `all times` links) from both contact blocks on the homepage.

## Test plan
- [x] Verified no remaining references to the scheduling links (`savvycal`, `Meeting Calendar`) anywhere in site source (`index.html`, `content/`, `layouts/`, `static/`).
- [x] Diff reviewed manually — both contact blocks edited symmetrically, HTML remains well-formed (no orphaned tags).
- [x] Confirmed no test/lint tooling exists for this static Hugo site; CI (Hugo build + link check) only runs on push to `master`, not on PR branches.
- [ ] Visual check of rendered page (not run — static content removal only, no layout/CSS changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)